### PR TITLE
Upgrading gcloud and removing need for keyFilename

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
         allowOverwrite: false
       },
 
-      requiredConfig: ['bucket', 'keyFilename', 'projectId'],
+      requiredConfig: ['bucket', 'projectId'],
 
       upload: function(/* context */) {
         var projectId      = this.readConfig('projectId');

--- a/lib/gcs.js
+++ b/lib/gcs.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var gcloud          = require('gcloud');
+var gcloud          = require('google-cloud');
 var CoreObject      = require('core-object');
 var Promise         = require('ember-cli/lib/ext/promise');
 var fs              = require('fs');

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-deploy-plugin": "^0.2.1",
-    "mime-types": "^2.1.9",
-    "gcloud": "^0.29.0"
+    "google-cloud": "^0.57.0",
+    "mime-types": "^2.1.9"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
-    "core-object": "^1.1.0",
     "ember-cli-babel": "^5.1.3",
+    "core-object": "^1.1.0",
     "ember-cli-deploy-plugin": "^0.2.1",
     "google-cloud": "^0.57.0",
     "mime-types": "^2.1.9"


### PR DESCRIPTION
I was having some issues with compiling the old deprecated `gcloud` npm package. I have upgraded it to the new `google-cloud` package which has the exact same API for datastore 👍 

I have also made `keyFilename` not a required config, this allows the end user to deploy using their **global** gcloud credentials.

Let me know if you have any questions 👍 