### PR TITLE
Add new makePublic option and fix timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ A flag to specify whether the revision should be overwritten if it already exist
 
 *Default:* `false`
 
+### makePublic
+
+A flag to make the `index.html` file public.
+
+*Default:* `true`
+
 ### How do I activate a revision?
 
 A user can activate a revision by either:

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ module.exports = {
         gzippedFiles: function(context) {
           return context.gzippedFiles || [];
         },
-        allowOverwrite: false
+        allowOverwrite: false,
+        makePublic: true
       },
 
       requiredConfig: ['bucket', 'projectId'],
@@ -73,13 +74,15 @@ module.exports = {
         var acl         = this.readConfig('acl');
         var revisionKey = this.readConfig('revisionKey');
         var filePattern = this.readConfig('filePattern');
+        var makePublic  = this.readConfig('makePublic');
 
         var options = {
           bucket: bucket,
           prefix: prefix,
           acl: acl,
           filePattern: filePattern,
-          revisionKey: revisionKey
+          revisionKey: revisionKey,
+          makePublic: makePublic
         };
 
         this.log('preparing to activate `' + revisionKey + '`', { verbose: true });

--- a/lib/gcs.js
+++ b/lib/gcs.js
@@ -95,14 +95,19 @@ module.exports = CoreObject.extend({
       var found = revisions.map(function(element) { return element.revision; }).indexOf(options.revisionKey);
       if (found >= 0) {
         return copyObject(indexKey).then(function(file) {
-          var makePublic  = RSVP.denodeify(file.makePublic.bind(file));
+          var promises = []
           var setMetadata = RSVP.denodeify(file.setMetadata.bind(file));
-          return makePublic().then(function() {
-            return setMetadata(meta).then(function(){
+          if (options.makePublic) {
+            var makePublic = RSVP.denodeify(file.makePublic.bind(file));
+            promises.push(makePublic())
+          }
+          promises.push(
+            setMetadata(meta).then(function() {
               plugin.log('✔  ' + revisionKey + " => " + indexKey);
-            });
-          }, function(err) {
-            plugin.log(err,err);
+            })
+          );
+          return RSVP.all(promises).catch(function(err) {
+            plugin.log(err, err);
           });
         });
       } else {
@@ -149,9 +154,10 @@ module.exports = CoreObject.extend({
         return data.revisions.sort(function(a, b) {
           return new Date(b.metadata.updated) - new Date(a.metadata.updated);
         }).map(function(d) {
-          var revision = d.name.substr(revisionPrefix.length);
-          var active = data.current && d.name.indexOf(data.current.metadata.revision) >= 0;
-          return { revision: revision, timestamp: d.metadata.updated, active: active };
+          var revision  = d.name.substr(revisionPrefix.length);
+          var timestamp = new Date(d.metadata.updated).getTime();
+          var active    = data.current && data.current.metadata && d.name.indexOf(data.current.metadata.revision) >= 0;
+          return { revision: revision, timestamp: timestamp, active: active };
         });
       });
   }


### PR DESCRIPTION
## Feature

- Add new `makePublic` option (true by default)
This option is similar as makePublic in https://github.com/knownasilya/ember-cli-deploy-gcloud-storage in order to makePublic the newly activated `index.html`

## Fix

- ember-cli-deploy-display-revisions excepts to have a timestamp in milliseconds since epoch (https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions/blob/ce118e49bfb6041fd5341f3b4677aa4674487702/lib/scm-table.js#L75)
